### PR TITLE
Fixing some of the Landsat Collection 01 (C01) data catalog chages

### DIFF
--- a/book/gee/06_data_analysis.ipynb
+++ b/book/gee/06_data_analysis.ipynb
@@ -212,7 +212,7 @@
    "outputs": [],
    "source": [
     "Map = geemap.Map()\n",
-    "image = ee.Image('LANDSAT/LC08/C01/T1/LC08_044034_20140318').select(['B4', 'B3', 'B2'])\n",
+    "image = ee.Image('LANDSAT/LC08/C02/T1/LC08_044034_20140318').select(['B4', 'B3', 'B2'])\n",
     "maxValue = image.reduce(ee.Reducer.max())\n",
     "Map.centerObject(image, 8)\n",
     "Map.addLayer(image, {}, 'Original image')\n",
@@ -1101,7 +1101,7 @@
     "start_date = '2020-01-01'\n",
     "end_date = '2021-01-01'\n",
     "collection = (\n",
-    "    ee.ImageCollection('LANDSAT/LC08/C01/T1_TOA')\n",
+    "    ee.ImageCollection('LANDSAT/LC08/C02/T1_TOA')\n",
     "    .filterBounds(roi)\n",
     "    .filterDate(start_date, end_date)\n",
     ")"
@@ -2245,7 +2245,7 @@
    "outputs": [],
    "source": [
     "# Make a cloud-free Landsat 8 TOA composite (from raw imagery).\n",
-    "l8 = ee.ImageCollection('LANDSAT/LC08/C01/T1')\n",
+    "l8 = ee.ImageCollection('LANDSAT/LC08/C02/T1')\n",
     "\n",
     "image = ee.Algorithms.Landsat.simpleComposite(\n",
     "    collection=l8.filterDate('2018-01-01', '2018-12-31'), asFloat=True\n",

--- a/book/gee/06_data_analysis.md
+++ b/book/gee/06_data_analysis.md
@@ -102,7 +102,7 @@ Map = geemap.Map()
 
 # Load an image collection, filtered so it's not too much data.
 collection = (
-    ee.ImageCollection('LANDSAT/LC08/C01/T1_TOA')
+    ee.ImageCollection('LANDSAT/LC08/C02/T1_TOA')
     .filterDate('2021-01-01', '2021-12-31')
     .filter(ee.Filter.eq('WRS_PATH', 44))
     .filter(ee.Filter.eq('WRS_ROW', 34))
@@ -128,7 +128,7 @@ print(median.bandNames().getInfo())
 
 ```{code-cell} ipython3
 Map = geemap.Map()
-image = ee.Image('LANDSAT/LC08/C01/T1/LC08_044034_20140318').select(['B4', 'B3', 'B2'])
+image = ee.Image('LANDSAT/LC08/C02/T1/LC08_044034_20140318').select(['B4', 'B3', 'B2'])
 maxValue = image.reduce(ee.Reducer.max())
 Map.centerObject(image, 8)
 Map.addLayer(image, {}, 'Original image')
@@ -662,7 +662,7 @@ Map
 start_date = '2020-01-01'
 end_date = '2021-01-01'
 collection = (
-    ee.ImageCollection('LANDSAT/LC08/C01/T1_TOA')
+    ee.ImageCollection('LANDSAT/LC08/C02/T1_TOA')
     .filterBounds(roi)
     .filterDate(start_date, end_date)
 )
@@ -1330,7 +1330,7 @@ ee_classifier.getInfo()
 
 ```{code-cell} ipython3
 # Make a cloud-free Landsat 8 TOA composite (from raw imagery).
-l8 = ee.ImageCollection('LANDSAT/LC08/C01/T1')
+l8 = ee.ImageCollection('LANDSAT/LC08/C02/T1')
 
 image = ee.Algorithms.Landsat.simpleComposite(
     collection=l8.filterDate('2018-01-01', '2018-12-31'), asFloat=True


### PR DESCRIPTION
Landsat Collection 01 (C01) is no longer available in GEE. 

This PR changes most reference  to Collection 02 (C02) changes in the GEE data catalog examples in 06_data_analysis.md
and 06_data_analysis.ipynb. 

NOTE: one GEE reference to LANDSAT/LC08/C01/T1_SR remains as I'm unsure of what should replace it as C02/T1_SR is not available in the GEE data catalog.

#8 